### PR TITLE
refactor: improve not-found URL handling in urlRouter

### DIFF
--- a/projects/srm/src/services/urlRouter.ts
+++ b/projects/srm/src/services/urlRouter.ts
@@ -41,12 +41,11 @@ const checkOldUrl = () => {
 }
 const notFoundToHomePage = () => {
   const urlParts = window.location.href.split('/');
-  const isNotFound = urlParts[urlParts.length - 1] === 'not-found';
+  const isNotFound = urlParts[urlParts.length - 1].includes('not-found');
   if (!isNotFound) return false;
   const newUrl = urlParts.slice(0, -1).join('/');
   window.location.replace(newUrl);
   return true;
-
 }
 
 export const urlRouter = () => {


### PR DESCRIPTION
added includes instead of  === to make sure this https://www.kolsherut.org.il/not-found#g35.03882/30.82956/12.00 returns to home